### PR TITLE
Introduce qmk_id dynamic console report detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+/qmk_id
+/qmk_id_test

--- a/50-qmk.rules
+++ b/50-qmk.rules
@@ -1,0 +1,65 @@
+# Atmel DFU
+### ATmega16U2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2fef", TAG+="uaccess"
+### ATmega32U2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff0", TAG+="uaccess"
+### ATmega16U4
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff3", TAG+="uaccess"
+### ATmega32U4
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff4", TAG+="uaccess"
+### AT90USB64
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff9", TAG+="uaccess"
+### AT90USB162
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ffa", TAG+="uaccess"
+### AT90USB128
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ffb", TAG+="uaccess"
+
+# Input Club
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1c11", ATTRS{idProduct}=="b007", TAG+="uaccess"
+
+# STM32duino
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1eaf", ATTRS{idProduct}=="0003", TAG+="uaccess"
+# STM32 DFU
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", TAG+="uaccess"
+
+# BootloadHID
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05df", TAG+="uaccess"
+
+# USBAspLoader
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05dc", TAG+="uaccess"
+
+# ModemManager should ignore the following devices
+# Atmel SAM-BA (Massdrop)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+
+# Caterina (Pro Micro)
+## Spark Fun Electronics
+### Pro Micro 3V3/8MHz
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9203", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+### Pro Micro 5V/16MHz
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9205", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+### LilyPad 3V3/8MHz (and some Pro Micro clones)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9207", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+## Pololu Electronics
+### A-Star 32U4
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1ffb", ATTRS{idProduct}=="0101", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+## Arduino SA
+### Leonardo
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0036", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+### Micro
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0037", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+## Adafruit Industries LLC
+### Feather 32U4
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="239a", ATTRS{idProduct}=="000c", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+### ItsyBitsy 32U4 3V3/8MHz
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="239a", ATTRS{idProduct}=="000d", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+### ItsyBitsy 32U4 5V/16MHz
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="239a", ATTRS{idProduct}=="000e", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+## dog hunter AG
+### Leonardo
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0036", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+### Micro
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0037", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+
+# hid_listen
+KERNEL=="hidraw*", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"

--- a/50-qmk.rules
+++ b/50-qmk.rules
@@ -1,65 +1,66 @@
 # Atmel DFU
 ### ATmega16U2
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2fef", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2fef", ENV{ID_QMK}="1"
 ### ATmega32U2
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff0", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff0", ENV{ID_QMK}="1"
 ### ATmega16U4
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff3", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff3", ENV{ID_QMK}="1"
 ### ATmega32U4
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff4", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff4", ENV{ID_QMK}="1"
 ### AT90USB64
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff9", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ff9", ENV{ID_QMK}="1"
 ### AT90USB162
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ffa", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ffa", ENV{ID_QMK}="1"
 ### AT90USB128
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ffb", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2ffb", ENV{ID_QMK}="1"
 
 # Input Club
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1c11", ATTRS{idProduct}=="b007", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1c11", ATTRS{idProduct}=="b007", ENV{ID_QMK}="1"
 
 # STM32duino
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1eaf", ATTRS{idProduct}=="0003", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1eaf", ATTRS{idProduct}=="0003", ENV{ID_QMK}="1"
 # STM32 DFU
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", ENV{ID_QMK}="1"
 
 # BootloadHID
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05df", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05df", ENV{ID_QMK}="1"
 
 # USBAspLoader
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05dc", TAG+="uaccess"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05dc", ENV{ID_QMK}="1"
 
 # ModemManager should ignore the following devices
 # Atmel SAM-BA (Massdrop)
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 # Caterina (Pro Micro)
 ## Spark Fun Electronics
 ### Pro Micro 3V3/8MHz
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9203", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9203", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ### Pro Micro 5V/16MHz
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9205", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9205", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ### LilyPad 3V3/8MHz (and some Pro Micro clones)
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9207", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9207", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ## Pololu Electronics
 ### A-Star 32U4
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1ffb", ATTRS{idProduct}=="0101", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1ffb", ATTRS{idProduct}=="0101", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ## Arduino SA
 ### Leonardo
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0036", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0036", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ### Micro
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0037", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0037", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ## Adafruit Industries LLC
 ### Feather 32U4
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="239a", ATTRS{idProduct}=="000c", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="239a", ATTRS{idProduct}=="000c", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ### ItsyBitsy 32U4 3V3/8MHz
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="239a", ATTRS{idProduct}=="000d", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="239a", ATTRS{idProduct}=="000d", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ### ItsyBitsy 32U4 5V/16MHz
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="239a", ATTRS{idProduct}=="000e", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="239a", ATTRS{idProduct}=="000e", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ## dog hunter AG
 ### Leonardo
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0036", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0036", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ### Micro
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0037", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0037", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 
-# hid_listen
-SUBSYSTEM=="hidraw", KERNEL=="hidraw*", TAG+="uaccess"
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ENV{ID_QMK}="1"
+
+ENV{ID_QMK}=="1", TAG+="uaccess"

--- a/50-qmk.rules
+++ b/50-qmk.rules
@@ -63,7 +63,10 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0036", ENV{ID_QMK
 ### Micro
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0037", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 
-SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ENV{ID_QMK}="1"
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", IMPORT{program}="qmk_id %S%p"
+
+# grant access to *all* hidraw devices
+# SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ENV{ID_QMK}="1"
 
 ENV{ID_QMK}=="1", TAG+="uaccess"
 

--- a/50-qmk.rules
+++ b/50-qmk.rules
@@ -1,3 +1,5 @@
+ACTION=="remove", GOTO="qmk_end"
+
 # Atmel DFU
 ### ATmega16U2
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="2fef", ENV{ID_QMK}="1"
@@ -64,3 +66,5 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0037", ENV{ID_QMK
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ENV{ID_QMK}="1"
 
 ENV{ID_QMK}=="1", TAG+="uaccess"
+
+LABEL="qmk_end"

--- a/50-qmk.rules
+++ b/50-qmk.rules
@@ -62,4 +62,4 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0036", TAG+="uacc
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0037", TAG+="uaccess", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 # hid_listen
-KERNEL=="hidraw*", MODE="0660", GROUP="plugdev", TAG+="uaccess", TAG+="udev-acl"
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", TAG+="uaccess"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+PREFIX?=/usr/local
+DESTDIR?=
+
+install:
+	install -m644 -D 50-qmk.rules $(DESTDIR)$(PREFIX)/udev/rules.d/50-qmk.rules
+
+.PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,21 @@
 PREFIX?=/usr/local
 DESTDIR?=
 
-install:
-	install -m644 -D 50-qmk.rules $(DESTDIR)$(PREFIX)/udev/rules.d/50-qmk.rules
+CC = gcc
+CFLAGS  = -g -Wall -Wextra -Wpedantic -std=c11
 
-.PHONY: install
+all: qmk_id
+
+install: qmk_id
+	install -m644 -D 50-qmk.rules $(DESTDIR)$(PREFIX)/lib/udev/rules.d/50-qmk.rules
+	install -m755 -D qmk_id $(DESTDIR)$(PREFIX)/lib/udev/qmk_id
+
+qmk_id: | test
+
+test: qmk_id_test
+	./qmk_id_test
+
+clean:
+	$(RM) qmk_id qmk_id_test
+
+.PHONY: install test clean

--- a/qmk_id.c
+++ b/qmk_id.c
@@ -1,0 +1,261 @@
+/*
+   Copyright 2021 Thomas Weißschuh <thomas@t-8ch.de>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 2 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+   */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <linux/audit.h>
+
+#define _cleanup_close __attribute__((__cleanup__(close_fd)))
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+#define syscall_arg(_n) (offsetof(struct seccomp_data, args[_n]))
+#define syscall_nr (offsetof(struct seccomp_data, nr))
+#define syscall_arch (offsetof(struct seccomp_data, arch))
+
+#ifndef O_PATH
+#    define O_PATH __O_PATH
+#endif
+
+#if __x86_64__
+#    define SECCOMP_ARCH_NATIVE AUDIT_ARCH_X86_64
+#elif __i386__
+#    define SECCOMP_ARCH_NATIVE AUDIT_ARCH_I386
+#elif __arm__
+#    define SECCOMP_ARCH_NATIVE AUDIT_ARCH_ARM
+#elif __aarch64__
+#    define SECCOMP_ARCH_NATIVE AUDIT_ARCH_AARCH64
+#elif __riscv
+#    if __riscv_xlen == 32
+#        define SECCOMP_ARCH_NATIVE AUDIT_ARCH_RISCV32
+#    elif __riscv_xlen == 64
+#        define SECCOMP_ARCH_NATIVE AUDIT_ARCH_RISCV64
+#    endif
+#else
+#    error Unknown target architecture
+#endif
+
+static const char *const qmk_id      = "ID_QMK=1\n";
+static const size_t      qmk_id_size = 9;
+
+static void close_fd(int *fd) {
+    if (fd && *fd != -1) {
+        close(*fd);
+        *fd = -1;
+    }
+}
+static int parse_item(const uint8_t *report, size_t report_size, size_t *offset, uint8_t item_size, uint32_t *item) {
+    if (*offset + item_size > report_size) {
+        return -EIO;
+    }
+    uint32_t r = 0;
+
+    for (int i = 0; i < 4; i++) {
+        r <<= 8;
+        if (i < item_size) {
+            r |= report[*offset + i];
+        }
+    }
+    *offset = *offset + item_size;
+
+    *item = ntohl(r);
+    return 0;
+}
+
+// including bType and bTag
+enum hid_item_type {
+    HID_TYPE_USAGE_PAGE = 0x01,
+    HID_TYPE_USAGE      = 0x02,
+    HID_TYPE_COLLECTION = 0x28,
+    HID_TYPE_LONG_ITEM  = 0xFF,
+};
+
+enum hid_collection_type {
+    HID_COLLECTION_APPLICATION = 0x01,
+};
+
+static int parse_type(const uint8_t *report, size_t report_size, size_t *offset, enum hid_item_type *item_type, uint8_t *item_size) {
+    if (*offset >= report_size) {
+        return -EIO;
+    }
+
+    uint8_t data = report[*offset];
+
+    // long items
+    if (data == 0xFE) {
+        *item_type = HID_TYPE_LONG_ITEM;
+        if (*offset + 2 >= report_size) {
+            return -EIO;
+        }
+        *item_size = report[*offset + 1];
+        *offset    = *offset + 2;
+        return 0;
+    }
+
+    *item_type = (enum hid_item_type)((data & 0xFC) >> 2);
+    *item_size = data & 0x03;
+    if (*item_size == 3) {
+        *item_size = 4;
+    }
+    *offset = *offset + 1;
+    return 0;
+}
+
+static int is_collection(const uint8_t *report, size_t report_size, uint32_t usage, enum hid_collection_type collection_type) {
+    uint32_t up = 0, u = 0, ct = 0;
+    size_t   offset = 0;
+    int      ret;
+
+    while (1) {
+        uint8_t            item_size;
+        enum hid_item_type item_type;
+        ret = parse_type(report, report_size, &offset, &item_type, &item_size);
+        if (ret) {
+            return ret;
+        }
+        if (item_type == HID_TYPE_LONG_ITEM) {
+            offset += item_size;
+            continue;
+        }
+        uint32_t item;
+        ret = parse_item(report, report_size, &offset, item_size, &item);
+        if (ret) {
+            return ret;
+        }
+        switch (item_type) {
+            case HID_TYPE_USAGE_PAGE:
+                up = item;
+                break;
+            case HID_TYPE_USAGE:
+                if (item_size <= 2) {
+                    item = (up << 16) | item;
+                }
+                u = item;
+                break;
+            case HID_TYPE_COLLECTION:
+                ct = item;
+                break;
+            case HID_TYPE_LONG_ITEM:
+                // can never happen
+                abort();
+        }
+        if (u && ct) {
+            return usage == u && collection_type == ct;
+        }
+    }
+}
+
+static int is_teensy_style_console(const uint8_t *report, size_t report_size) { return is_collection(report, report_size, UINT32_C(0xFF310074), HID_COLLECTION_APPLICATION); }
+
+static int apply_syscall_filter(void) {
+    union {
+        struct {
+            uint32_t lo, hi;
+        };
+        uint64_t raw;
+    } qmk_id_addr;
+
+    qmk_id_addr.raw = (uintptr_t)qmk_id;
+
+    // only allow rt_sigreturn(), exit(), exit_group() and write(STDOUT_FILENO, "QMK_ID=1", 9)
+    struct sock_filter filter[] = {
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, syscall_arch),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SECCOMP_ARCH_NATIVE, 0, 14),
+
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, syscall_nr),
+
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_rt_sigreturn, 11, 0),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_exit_group, 10, 0),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_exit, 9, 0),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, __NR_write, 0, 9),
+
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, syscall_arg(0)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, STDOUT_FILENO, 0, 7),
+
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, syscall_arg(1)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, qmk_id_addr.lo, 0, 5),
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, syscall_arg(1) + 4),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, qmk_id_addr.hi, 0, 3),
+
+        BPF_STMT(BPF_LD | BPF_W | BPF_ABS, syscall_arg(2)),
+        BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, qmk_id_size, 0, 1),
+
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW),
+        BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_KILL_PROCESS),
+    };
+
+    struct sock_fprog prog = {
+        .len    = ARRAY_SIZE(filter),
+        .filter = filter,
+    };
+
+    if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)) {
+        return 1;
+    }
+
+    if (prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &prog)) {
+        return 1;
+    }
+    return 0;
+}
+
+static int read_report_descriptor(const char *report_dir, uint8_t *buf, size_t buf_size) {
+    int _cleanup_close sysfs_fd = openat(-1, report_dir, O_PATH | O_DIRECTORY);
+    if (sysfs_fd == -1) {
+        return -1;
+    }
+    int _cleanup_close report_fd = openat(sysfs_fd, "device/report_descriptor", O_RDONLY);
+    if (report_fd == -1) {
+        return -1;
+    }
+
+    return read(report_fd, buf, buf_size);
+}
+
+int main(int argc, char **argv) {
+    if (argc != 2) {
+        return EINVAL;
+    }
+
+    uint8_t buf[100];
+    ssize_t r = read_report_descriptor(argv[1], buf, sizeof(buf));
+    if (r == -1) {
+        return errno;
+    }
+
+    if (apply_syscall_filter()) {
+        return errno;
+    }
+
+    int is_c = is_teensy_style_console(buf, r);
+    if (is_c < 0) {
+        return -is_c;
+    }
+    if (is_c > 0) {
+        write(STDOUT_FILENO, qmk_id, qmk_id_size);
+    }
+    return 0;
+}

--- a/qmk_id_test.c
+++ b/qmk_id_test.c
@@ -1,0 +1,37 @@
+#define main original_main
+#include "qmk_id.c"
+#undef main
+
+#include <stdio.h>
+
+int main() {
+    struct testcase {
+        char    description[100];
+        int     expected_ret;
+        size_t  report_size;
+        uint8_t report[100];
+    };
+    struct testcase testcases[] = {
+        {"empty input", -EIO, 0, {0}}, {"basic qmk console descriptor", 1, 7, {0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}}, {"different usage page", 0, 7, {0x06, 0x30, 0xFF, 0x09, 0x74, 0xA1, 0x01}}, {"different usage", 0, 7, {0x06, 0x31, 0xFF, 0x09, 0x73, 0xA1, 0x01}}, {"empty long items", 1, 10, {0xFE, 0X00, 0xF0, 0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}}, {"long items", 1, 11, {0xFE, 0X01, 0xF0, 0x00, 0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
+    };
+
+    int num_testcases = ARRAY_SIZE(testcases);
+
+    printf("1..%d\n", num_testcases);
+
+    int failed = 0;
+
+    for (int i = 0; i < num_testcases; i++) {
+        struct testcase tc  = testcases[i];
+        int             ret = is_teensy_style_console(tc.report, tc.report_size);
+
+        if (ret == tc.expected_ret) {
+            printf("ok %d - %s\n", i + 1, tc.description);
+        } else {
+            failed++;
+            printf("not ok %d - %s\n  result %d != expected %d\n", i + 1, tc.description, ret, tc.expected_ret);
+        }
+    }
+
+    return failed;
+}


### PR DESCRIPTION
This utility detects the teensy debug console report descriptor.
Therefore the need to either hardcode all QMK keyboards or grant broad permissions on all hidraw devices is alleviated.

Continuation of https://github.com/qmk/qmk_firmware/pull/12980