### PR TITLE
Add Keyboardio Atreus 2 Bootloader to udev rules

### DIFF
--- a/50-qmk.rules
+++ b/50-qmk.rules
@@ -35,6 +35,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="16c0", ATTRS{idProduct}=="05dc", ENV{ID_QMK
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="6124", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 # Caterina (Pro Micro)
+## pid.codes shared PID
+### Keyboardio Atreus 2 Bootloader
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="2302", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"
 ## Spark Fun Electronics
 ### Pro Micro 3V3/8MHz
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b4f", ATTRS{idProduct}=="9203", ENV{ID_QMK}="1", ENV{ID_MM_DEVICE_IGNORE}="1"


### PR DESCRIPTION
## Description

The Keyboardio Atreus 2 Bootloader is a clone of the Caterina bootloader with different USB VID:PID values (`1209:2302`):

  https://github.com/keyboardio/Atreus2-Bootloader

Add the appropriate udev rule for that bootloader.

Corresponding PR for `qmk_firmware`: qmk/qmk_firmware#15241
