### PR TITLE
qmk_id: parse descriptor only once

### DIFF
--- a/qmk_id.c
+++ b/qmk_id.c
@@ -191,7 +191,6 @@ static int find_qmk_endpoint(const uint8_t *report, size_t report_size, const st
             return 1;
         }
     }
-    *out = NULL;
     return 0;
 }
 

--- a/qmk_id.c
+++ b/qmk_id.c
@@ -128,7 +128,7 @@ static int parse_type(const uint8_t *report, size_t report_size, size_t *offset,
     return 0;
 }
 
-static int is_collection(const uint8_t *report, size_t report_size, uint32_t usage, enum hid_collection_type collection_type) {
+static int get_collection(const uint8_t *report, size_t report_size, uint32_t *usage, enum hid_collection_type *collection_type) {
     uint32_t up = 0, u = 0, ct = 0;
     size_t   offset = 0;
     int      ret;
@@ -167,7 +167,9 @@ static int is_collection(const uint8_t *report, size_t report_size, uint32_t usa
                 abort();
         }
         if (u && ct) {
-            return usage == u && collection_type == ct;
+            *usage           = u;
+            *collection_type = ct;
+            return 0;
         }
     }
 }
@@ -183,10 +185,16 @@ static const struct qmk_endpoint qmk_endpoints[] = {
 };
 
 static int find_qmk_endpoint(const uint8_t *report, size_t report_size, const struct qmk_endpoint **out) {
+    enum hid_collection_type collection_type;
+    uint32_t                 usage;
+    int                      ret;
+
+    ret = get_collection(report, report_size, &usage, &collection_type);
+    if (ret < 0) return ret;
+    if (collection_type != HID_COLLECTION_APPLICATION) return 0;
+
     for (size_t i = 0; i < ARRAY_SIZE(qmk_endpoints); i++) {
-        int ret = is_collection(report, report_size, qmk_endpoints[i].usage, HID_COLLECTION_APPLICATION);
-        if (ret < 0) return ret;
-        if (ret > 0) {
+        if (qmk_endpoints[i].usage == usage) {
             *out = &qmk_endpoints[i];
             return 1;
         }

--- a/qmk_id_test.c
+++ b/qmk_id_test.c
@@ -53,6 +53,7 @@ int main() {
 
     int num_testcases = ARRAY_SIZE(testcases);
 
+    printf("TAP version 13\n");
     printf("1..%d\n", num_testcases);
 
     int failed = 0;

--- a/qmk_id_test.c
+++ b/qmk_id_test.c
@@ -21,33 +21,30 @@
 
 int main() {
     struct testcase {
-        char     description[100];
-        int      expected_ret;
-        uint32_t usage;
-        size_t   report_size;
-        uint8_t  report[100];
+        char        description[100];
+        int         expected_ret;
+        const char *expected_output;
+        size_t      report_size;
+        uint8_t     report[100];
     };
 
     // clang-format off
     struct testcase testcases[] = {
+        {"empty input",                  -EIO, NULL,              0,  {0}},
         // console (Teensy-style, 0xFF310074)
-        {"console: empty input",                  -EIO, 0xFF310074U, 0,  {0}},
-        {"console: basic descriptor",             1,    0xFF310074U, 7,  {0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
-        {"console: different usage page",         0,    0xFF310074U, 7,  {0x06, 0x30, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
-        {"console: different usage",              0,    0xFF310074U, 7,  {0x06, 0x31, 0xFF, 0x09, 0x73, 0xA1, 0x01}},
-        {"console: empty long items",             1,    0xFF310074U, 10, {0xFE, 0X00, 0xF0, 0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
-        {"console: long items",                   1,    0xFF310074U, 11, {0xFE, 0X01, 0xF0, 0x00, 0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
+        {"console: basic descriptor",             1,    ep_output_console, 7,  {0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
+        {"console: different usage page",         0,    NULL,              7,  {0x06, 0x30, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
+        {"console: different usage",              0,    NULL,              7,  {0x06, 0x31, 0xFF, 0x09, 0x73, 0xA1, 0x01}},
+        {"console: empty long items",             1,    ep_output_console, 10, {0xFE, 0X00, 0xF0, 0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
+        {"console: long items",                   1,    ep_output_console, 11, {0xFE, 0X01, 0xF0, 0x00, 0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
         // raw HID (0xFF600061)
-        {"raw hid: empty input",                  -EIO, 0xFF600061U, 0,  {0}},
-        {"raw hid: basic descriptor",             1,    0xFF600061U, 7,  {0x06, 0x60, 0xFF, 0x09, 0x61, 0xA1, 0x01}},
-        {"raw hid: different usage page",         0,    0xFF600061U, 7,  {0x06, 0x31, 0xFF, 0x09, 0x61, 0xA1, 0x01}},
-        {"raw hid: different usage",              0,    0xFF600061U, 7,  {0x06, 0x60, 0xFF, 0x09, 0x60, 0xA1, 0x01}},
-        {"raw hid: console descriptor no match",  0,    0xFF600061U, 7,  {0x06, 0x31, 0xFF, 0x09, 0x74, 0xA1, 0x01}},
+        {"raw hid: basic descriptor",             1,    ep_output_raw_hid, 7,  {0x06, 0x60, 0xFF, 0x09, 0x61, 0xA1, 0x01}},
+        {"raw hid: different usage page",         0,    NULL,              7,  {0x06, 0x31, 0xFF, 0x09, 0x61, 0xA1, 0x01}},
+        {"raw hid: different usage",              0,    NULL,              7,  {0x06, 0x60, 0xFF, 0x09, 0x60, 0xA1, 0x01}},
         // XAP (0xFF510058)
-        {"xap: empty input",                      -EIO, 0xFF510058U, 0,  {0}},
-        {"xap: basic descriptor",                 1,    0xFF510058U, 7,  {0x06, 0x51, 0xFF, 0x09, 0x58, 0xA1, 0x01}},
-        {"xap: different usage page",             0,    0xFF510058U, 7,  {0x06, 0x31, 0xFF, 0x09, 0x58, 0xA1, 0x01}},
-        {"xap: different usage",                  0,    0xFF510058U, 7,  {0x06, 0x51, 0xFF, 0x09, 0x57, 0xA1, 0x01}},
+        {"xap: basic descriptor",                 1,    ep_output_xap,     7,  {0x06, 0x51, 0xFF, 0x09, 0x58, 0xA1, 0x01}},
+        {"xap: different usage page",             0,    NULL,              7,  {0x06, 0x31, 0xFF, 0x09, 0x58, 0xA1, 0x01}},
+        {"xap: different usage",                  0,    NULL,              7,  {0x06, 0x51, 0xFF, 0x09, 0x57, 0xA1, 0x01}},
     };
     // clang-format on
 
@@ -59,14 +56,19 @@ int main() {
     int failed = 0;
 
     for (int i = 0; i < num_testcases; i++) {
-        struct testcase tc  = testcases[i];
-        int             ret = is_collection(tc.report, tc.report_size, tc.usage, HID_COLLECTION_APPLICATION);
+        struct testcase            tc       = testcases[i];
+        const struct qmk_endpoint *endpoint = NULL;
+        int                        ret      = find_qmk_endpoint(tc.report, tc.report_size, &endpoint);
+        const char                *output   = endpoint ? endpoint->output : NULL;
 
-        if (ret == tc.expected_ret) {
-            printf("ok %d - %s\n", i + 1, tc.description);
-        } else {
+        if (ret != tc.expected_ret) {
             failed++;
             printf("not ok %d - %s\n  result %d != expected %d\n", i + 1, tc.description, ret, tc.expected_ret);
+        } else if (output != tc.expected_output) {
+            failed++;
+            printf("not ok %d - %s\n  output '%s' != expected '%s'\n", i + 1, tc.description, output, tc.expected_output);
+        } else {
+            printf("ok %d - %s\n", i + 1, tc.description);
         }
     }
 


### PR DESCRIPTION
Currently the descriptor is parsed again for each kind of collection,
which is pointless. Parse the report only once and then compare that
against the different kinds of endpoints.

Some more details in the commit message, please don't squash them.